### PR TITLE
fix: hanging if error channel is full (#11)

### DIFF
--- a/kinesumer.go
+++ b/kinesumer.go
@@ -432,7 +432,7 @@ func (k *Kinesumer) consumePipe(stream string, shard *Shard) {
 
 			output, err := k.client.SubscribeToShardWithContext(ctx, input)
 			if err != nil {
-				k.sendErrorOrIgnore(errors.WithStack(err))
+				k.sendOrDiscardError(errors.WithStack(err))
 				cancel()
 				continue
 			}
@@ -555,7 +555,7 @@ func (k *Kinesumer) consumeOnce(stream string, shard *Shard) bool {
 
 	shardIter, err := k.getNextShardIterator(ctx, stream, shard.ID)
 	if err != nil {
-		k.sendErrorOrIgnore(errors.WithStack(err))
+		k.sendOrDiscardError(errors.WithStack(err))
 
 		var riue *kinesis.ResourceInUseException
 		return errors.As(err, &riue)
@@ -566,7 +566,7 @@ func (k *Kinesumer) consumeOnce(stream string, shard *Shard) bool {
 		ShardIterator: shardIter,
 	})
 	if err != nil {
-		k.sendErrorOrIgnore(errors.WithStack(err))
+		k.sendOrDiscardError(errors.WithStack(err))
 
 		var riue *kinesis.ResourceInUseException
 		if errors.As(err, &riue) {
@@ -640,16 +640,15 @@ func (k *Kinesumer) Refresh(streams []string) {
 }
 
 // Errors returns error channel.
-// you must read from the Errors() channel or Kinesumer will ignore error if channel is blocked.
 func (k *Kinesumer) Errors() <-chan error {
 	return k.errors
 }
 
-func (k *Kinesumer) sendErrorOrIgnore(err error) {
+func (k *Kinesumer) sendOrDiscardError(err error) {
 	select {
 	case k.errors <- err:
 	default:
-		// if there are no error listeners, error is ignored.
+		// if there are no error listeners, error is discarded.
 	}
 }
 

--- a/kinesumer.go
+++ b/kinesumer.go
@@ -638,6 +638,7 @@ func (k *Kinesumer) Refresh(streams []string) {
 }
 
 // Errors returns error channel.
+// You must read from the Errors() channel or Kinesumer will deadlock.
 func (k *Kinesumer) Errors() <-chan error {
 	return k.errors
 }

--- a/kinesumer.go
+++ b/kinesumer.go
@@ -638,7 +638,7 @@ func (k *Kinesumer) Refresh(streams []string) {
 }
 
 // Errors returns error channel.
-// You must read from the Errors() channel or Kinesumer will deadlock.
+// you must read from the Errors() channel or Kinesumer will be deadlocked.
 func (k *Kinesumer) Errors() <-chan error {
 	return k.errors
 }

--- a/kinesumer.go
+++ b/kinesumer.go
@@ -649,7 +649,7 @@ func (k *Kinesumer) sendErrorOrIgnore(err error) {
 	select {
 	case k.errors <- err:
 	default:
-		// If there are no error listeners, error is ignored.
+		// if there are no error listeners, error is ignored.
 	}
 }
 


### PR DESCRIPTION
Solved:[ issue-11](https://github.com/daangn/kinesumer/issues/11)

Kinesumer occurs deadlock when errors don't be consumed properly.

So possibility of deadlock should be clarified in `Errors` function doc.
